### PR TITLE
feat(gherkin): can define tests in bulk given array of cases

### DIFF
--- a/test/gherkin.go
+++ b/test/gherkin.go
@@ -243,7 +243,7 @@ func mergeLabels(startLabel, endLabel []string) []string {
 	label := startLabel
 	startLabelLength := len(startLabel)
 	// second last word is always the last action word
-	if startLabelLength > 0 && startLabel[startLabelLength-2] == endLabel[0] {
+	if startLabelLength >= 2 && startLabel[startLabelLength-2] == endLabel[0] {
 		label = append(label, _and)
 	}
 	return append(label, endLabel...)

--- a/test/gherkin.go
+++ b/test/gherkin.go
@@ -31,6 +31,11 @@ type ThenStatement interface {
 	Then(description string, execution func(t *testing.T)) Runner
 }
 
+// ForEachStatement is used to create a set of tests for each of the test case items
+type ForEachStatement[T any] interface {
+	ForEach(createRunner func(testCase T) Runner) Runner
+}
+
 // Runner executes the test - do not implement yourself
 type Runner interface {
 	Run(t *testing.T, repeats ...int) bool
@@ -49,6 +54,10 @@ type when struct {
 type then struct {
 	label []string
 	test  []func(t *testing.T)
+}
+
+type testCases[T any] struct {
+	items []T
 }
 
 type multiRunner struct {
@@ -81,6 +90,13 @@ func Then(description string, setup func(t *testing.T)) Runner {
 	return runner{
 		label: []string{_then, description},
 		test:  []func(t *testing.T){setup},
+	}
+}
+
+// TestCases takes an array of arbitrary items to then generate a test for each of the test case items
+func TestCases[T any](items []T) ForEachStatement[T] {
+	return testCases[T]{
+		items: items,
 	}
 }
 
@@ -134,6 +150,18 @@ func (t then) Then(description string, execution func(t *testing.T)) Runner {
 		label: append(t.label, _then, description),
 		test:  append(t.test, execution),
 	}
+}
+
+// ForEach generates a test for each test case
+func (tc testCases[T]) ForEach(createRunner func(testCase T) Runner) Runner {
+
+	runners := make([]Runner, len(tc.items))
+
+	for i, v := range tc.items {
+		runners[i] = createRunner(v)
+	}
+
+	return branch([]string{}, []func(t *testing.T){}, runners)
 }
 
 // Run executes all defined test paths. Optionally, each path is repeated a given number of times
@@ -213,8 +241,9 @@ func concatRunner(startLabel []string, startTest []func(t *testing.T), r runner)
 
 func mergeLabels(startLabel, endLabel []string) []string {
 	label := startLabel
+	startLabelLength := len(startLabel)
 	// second last word is always the last action word
-	if startLabel[len(startLabel)-2] == endLabel[0] {
+	if startLabelLength > 0 && startLabel[startLabelLength-2] == endLabel[0] {
 		label = append(label, _and)
 	}
 	return append(label, endLabel...)

--- a/test/gherkin_test.go
+++ b/test/gherkin_test.go
@@ -1,6 +1,7 @@
 package testutils_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -36,15 +37,24 @@ func TestGherkinSyntax(t *testing.T) {
 					assertNameEquals(t, testLabel)
 					testPaths++
 				}),
+			TestCases([]int16{1, 2, 3}).ForEach(func(tc int16) Runner {
+				description := fmt.Sprintf("test case %v", tc)
+				return When(description, func(t *testing.T) { testLabel += fmt.Sprintf(" WHEN %s", description) }).
+					Then("we check outcome for test case", func(t *testing.T) {
+						testLabel += " THEN we check outcome for test case"
+						assertNameEquals(t, testLabel)
+						testPaths++
+					})
+			}),
 		)
 
 	testSetup.Run(t)
-	assert.Equal(t, 3, testPaths)
+	assert.Equal(t, 6, testPaths)
 
 	// do the same execution again, so tests will end in "#01"
 	testPaths = 0
 	testSetup.Run(t, 15)
-	assert.Equal(t, 3*15, testPaths)
+	assert.Equal(t, 6*15, testPaths)
 }
 
 func TestGherkinPanicsGIVENAfterWHEN(t *testing.T) {


### PR DESCRIPTION
Example:
```
TestCases([]T{value1, value2, value3}).ForEach(func(tc T) Runner {
    description := fmt.Sprintf("test case %v", tc)
    return When(description, func(t *testing.T) {
        // ...
    })
})
```

## Description

It is a common need to perform a set of similar tests for a collection of arbitrary values. Such functionality exists in many unit testing frameworks, e.g.: [NUnit](https://docs.nunit.org/articles/nunit/writing-tests/attributes/testcase.html), [jest](https://jestjs.io/docs/api#testonlyeachtablename-fn-1).

## Todos

- [x] Unit tests
- [x] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [x] Tag type of change

## Steps to Test

Execute in the root of the repository
```bash
go test ./...
```

## Expected Behaviour

Unit tests should pass

## Other Notes
