### PR TITLE
feat: add function to zero out a value

### DIFF
--- a/funcs/funcs.go
+++ b/funcs/funcs.go
@@ -2,6 +2,7 @@ package funcs
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/pkg/errors"
 )
@@ -75,4 +76,8 @@ func Or[T any](predicateFuncs ...func(T) bool) func(T) bool {
 
 		return false
 	}
+}
+
+func ZeroPtr[T any](ptr T) T {
+	return reflect.New(reflect.TypeOf(ptr)).Elem().Interface().(T)
 }

--- a/funcs/funcs_test.go
+++ b/funcs/funcs_test.go
@@ -89,3 +89,14 @@ func TestMustOk(t *testing.T) {
 	})
 	assert.EqualValues(t, 1, MustOk(okFunc()))
 }
+
+func TestZero(t *testing.T) {
+	input := "test"
+
+	zero(&input) // make sure it even works when calling a separate function
+	assert.IsType(t, new(string), &input)
+}
+
+func zero(input any) {
+	ZeroPtr(input)
+}


### PR DESCRIPTION
This function takes a pointer and creates a new object of the same underlying type. This is useful for unmarshalling protobufs in a loop condition, where we cannot always pass in a new instance.
