### PR TITLE
feat(chans): add new chans functions

### DIFF
--- a/chans/chans.go
+++ b/chans/chans.go
@@ -171,12 +171,3 @@ func RangeBig(from, to *big.Int) <-chan *big.Int {
 
 	return newCh
 }
-
-// RangeBigExcl creates a channel that exclusively contains all values from `from` to `to`.
-// I.e. the first value will be `from+1` and the last value will be `to-1`.
-func RangeBigExcl(from, to *big.Int) <-chan *big.Int {
-	from = (&big.Int{}).Add(from, oneBig)
-	to = (&big.Int{}).Sub(to, oneBig)
-
-	return RangeBig(from, to)
-}

--- a/chans/chans.go
+++ b/chans/chans.go
@@ -94,7 +94,7 @@ func Map[T, S any](source <-chan T, f func(T) S, capacity ...int) <-chan S {
 	if len(capacity) > 0 {
 		out = make(chan S, capacity[0])
 	} else {
-		out = make(chan S, cap(source))
+		out = make(chan S)
 	}
 
 	go func() {

--- a/chans/chans.go
+++ b/chans/chans.go
@@ -86,9 +86,16 @@ func FromValues[T any](values ...T) <-chan T {
 	return newCh
 }
 
-// Map maps a channel of T to a channel of S. Runs until source channel is closed
-func Map[T, S any](source <-chan T, f func(T) S) <-chan S {
-	out := make(chan S, cap(source))
+// Map maps a channel of T to a channel of S. Runs until source channel is closed.
+// By default, output channel has the same capacity as the source channel.
+// Desired capacity of the output channel can be specified via an optional argument.
+func Map[T, S any](source <-chan T, f func(T) S, capacity ...int) <-chan S {
+	var out chan S
+	if len(capacity) > 0 {
+		out = make(chan S, capacity[0])
+	} else {
+		out = make(chan S, cap(source))
+	}
 
 	go func() {
 		defer close(out)

--- a/chans/chans.go
+++ b/chans/chans.go
@@ -51,7 +51,7 @@ func Filter[T any](source <-chan T, predicate func(T) bool) <-chan T {
 
 // Flatten flattens a chan of chans into a chan of elements
 func Flatten[T any](source <-chan <-chan T) <-chan T {
-	out := make(chan T, cap(source))
+	out := make(chan T)
 
 	go func() {
 		defer close(out)

--- a/chans/chans_test.go
+++ b/chans/chans_test.go
@@ -2,6 +2,9 @@ package chans_test
 
 import (
 	"context"
+	testutils "github.com/axelarnetwork/utils/test"
+	"github.com/stretchr/testify/require"
+	"math/big"
 	"sync"
 	"testing"
 	"time"
@@ -10,16 +13,50 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMap(t *testing.T) {
-	source := make(chan int, 1)
-	defer close(source)
+func TestConcat(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	even := chans.Map(source, func(i int) bool { return i%2 == 0 })
+	var (
+		cch1 = chans.FromValues(1, 2, 3)
+		cch2 = chans.FromValues(4, 5, 6)
+		cch3 = chans.FromValues(7, 8, 9)
+	)
 
-	for i := 0; i < 100; i++ {
-		source <- i
-		assert.Equal(t, i%2 == 0, <-even)
-	}
+	go func() {
+		defer cancel()
+
+		concatenated := chans.Concat(cch1, cch2, cch3)
+
+		for i := 1; i <= 9; i++ {
+			require.EqualValues(t, i, <-concatenated)
+		}
+
+		select {
+		case _, ok := <-concatenated:
+			if ok {
+				assert.FailNow(t, "channel contains unexpected items")
+			}
+		default:
+		}
+	}()
+
+	testutils.FailOnTimeout(ctx, t, 1*time.Second)
+}
+
+func TestEmpty(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		defer cancel()
+
+		for range chans.Empty[struct{}]() {
+			require.FailNow(t, "non empty channel was returned")
+		}
+	}()
+
+	testutils.FailOnTimeout(ctx, t, 1*time.Second)
 }
 
 func TestFilter(t *testing.T) {
@@ -35,26 +72,6 @@ func TestFilter(t *testing.T) {
 	for x := range even {
 		assert.Equal(t, 0, x%2)
 	}
-}
-
-func TestForEach(t *testing.T) {
-	source := make(chan int, 100)
-	total := 0
-
-	wg := &sync.WaitGroup{}
-	wg.Add(100)
-	chans.ForEach(source, func(n int) {
-		total += n
-		wg.Done()
-	})
-
-	for i := 0; i < 100; i++ {
-		source <- 1
-	}
-	close(source)
-	wg.Wait()
-
-	assert.Equal(t, 100, total)
 }
 
 func TestFlatten(t *testing.T) {
@@ -83,6 +100,138 @@ func TestFlatten(t *testing.T) {
 	close(source)
 	wg.Wait()
 	assert.Equal(t, 4851, total)
+}
+
+func TestForEach(t *testing.T) {
+	source := make(chan int, 100)
+	total := 0
+
+	wg := &sync.WaitGroup{}
+	wg.Add(100)
+	chans.ForEach(source, func(n int) {
+		total += n
+		wg.Done()
+	})
+
+	for i := 0; i < 100; i++ {
+		source <- 1
+	}
+	close(source)
+	wg.Wait()
+
+	assert.Equal(t, 100, total)
+}
+
+func TestFromValues(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		defer cancel()
+
+		values := chans.FromValues(1, 2, 3)
+
+		for i := 1; i <= 3; i++ {
+			require.EqualValues(t, i, <-values)
+		}
+
+		select {
+		case _, ok := <-values:
+			if ok {
+				assert.FailNow(t, "channel contains unexpected items")
+			}
+		default:
+		}
+	}()
+
+	testutils.FailOnTimeout(ctx, t, 1*time.Second)
+}
+
+func TestMap(t *testing.T) {
+	source := make(chan int, 1)
+	defer close(source)
+
+	even := chans.Map(source, func(i int) bool { return i%2 == 0 })
+
+	for i := 0; i < 100; i++ {
+		source <- i
+		assert.Equal(t, i%2 == 0, <-even)
+	}
+}
+
+func TestRange(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		defer cancel()
+
+		values := chans.Range(-3, 2)
+
+		for i := -3; i <= 2; i++ {
+			require.EqualValues(t, i, <-values)
+		}
+
+		select {
+		case _, ok := <-values:
+			if ok {
+				assert.FailNow(t, "channel contains unexpected items")
+			}
+		default:
+		}
+	}()
+
+	testutils.FailOnTimeout(ctx, t, 1*time.Second)
+}
+
+func TestRangeBig(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		defer cancel()
+
+		values := chans.RangeBig(big.NewInt(-3), big.NewInt(2))
+
+		for i := -3; i <= 2; i++ {
+			require.EqualValues(t, big.NewInt(int64(i)), <-values)
+		}
+
+		select {
+		case _, ok := <-values:
+			if ok {
+				assert.FailNow(t, "channel contains unexpected items")
+			}
+		default:
+		}
+	}()
+
+	testutils.FailOnTimeout(ctx, t, 1*time.Second)
+}
+
+func TestRangeBigExcl(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		defer cancel()
+
+		values := chans.RangeBigExcl(big.NewInt(-3), big.NewInt(2))
+
+		for i := -2; i <= 1; i++ {
+			require.EqualValues(t, big.NewInt(int64(i)), <-values)
+		}
+
+		select {
+		case _, ok := <-values:
+			if ok {
+				assert.FailNow(t, "channel contains unexpected items")
+			}
+		default:
+		}
+	}()
+
+	testutils.FailOnTimeout(ctx, t, 1*time.Second)
 }
 
 func TestPushPop(t *testing.T) {

--- a/chans/chans_test.go
+++ b/chans/chans_test.go
@@ -39,18 +39,7 @@ func TestConcat(t *testing.T) {
 }
 
 func TestEmpty(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	go func() {
-		defer cancel()
-
-		for range chans.Empty[struct{}]() {
-			require.FailNow(t, "non empty channel was returned")
-		}
-	}()
-
-	testutils.FailOnTimeout(ctx, t, 1*time.Second)
+	assert.Empty(t, chans.Empty[struct{}]())
 }
 
 func TestFilter(t *testing.T) {

--- a/chans/chans_test.go
+++ b/chans/chans_test.go
@@ -174,25 +174,6 @@ func TestRangeBig(t *testing.T) {
 	testutils.FailOnTimeout(ctx, t, 1*time.Second)
 }
 
-func TestRangeBigExcl(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	go func() {
-		defer cancel()
-
-		values := chans.RangeBigExcl(big.NewInt(-3), big.NewInt(2))
-
-		for i := -2; i <= 1; i++ {
-			require.EqualValues(t, big.NewInt(int64(i)), <-values)
-		}
-
-		assert.Empty(t, values)
-	}()
-
-	testutils.FailOnTimeout(ctx, t, 1*time.Second)
-}
-
 func TestPushPop(t *testing.T) {
 	t.Run("valid ctx", func(t *testing.T) {
 		c := make(chan int, 1)

--- a/chans/chans_test.go
+++ b/chans/chans_test.go
@@ -14,17 +14,15 @@ import (
 )
 
 func TestConcat(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	var (
+		done = make(chan struct{})
 		cch1 = chans.FromValues(1, 2, 3)
 		cch2 = chans.FromValues(4, 5, 6)
 		cch3 = chans.FromValues(7, 8, 9)
 	)
 
 	go func() {
-		defer cancel()
+		defer close(done)
 
 		concatenated := chans.Concat(cch1, cch2, cch3)
 
@@ -35,7 +33,7 @@ func TestConcat(t *testing.T) {
 		assert.Empty(t, concatenated)
 	}()
 
-	testutils.FailOnTimeout(ctx, t, 1*time.Second)
+	testutils.FailOnTimeout(t, done, 1*time.Second)
 }
 
 func TestEmpty(t *testing.T) {
@@ -106,11 +104,10 @@ func TestForEach(t *testing.T) {
 }
 
 func TestFromValues(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	done := make(chan struct{})
 
 	go func() {
-		defer cancel()
+		defer close(done)
 
 		values := chans.FromValues(1, 2, 3)
 
@@ -121,7 +118,7 @@ func TestFromValues(t *testing.T) {
 		assert.Empty(t, values)
 	}()
 
-	testutils.FailOnTimeout(ctx, t, 1*time.Second)
+	testutils.FailOnTimeout(t, done, 1*time.Second)
 }
 
 func TestMap(t *testing.T) {
@@ -137,11 +134,10 @@ func TestMap(t *testing.T) {
 }
 
 func TestRange(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	done := make(chan struct{})
 
 	go func() {
-		defer cancel()
+		defer close(done)
 
 		values := chans.Range(-3, 2)
 
@@ -152,15 +148,14 @@ func TestRange(t *testing.T) {
 		assert.Empty(t, values)
 	}()
 
-	testutils.FailOnTimeout(ctx, t, 1*time.Second)
+	testutils.FailOnTimeout(t, done, 1*time.Second)
 }
 
 func TestRangeBig(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	done := make(chan struct{})
 
 	go func() {
-		defer cancel()
+		defer close(done)
 
 		values := chans.RangeBig(big.NewInt(-3), big.NewInt(2))
 
@@ -171,7 +166,7 @@ func TestRangeBig(t *testing.T) {
 		assert.Empty(t, values)
 	}()
 
-	testutils.FailOnTimeout(ctx, t, 1*time.Second)
+	testutils.FailOnTimeout(t, done, 1*time.Second)
 }
 
 func TestPushPop(t *testing.T) {

--- a/chans/chans_test.go
+++ b/chans/chans_test.go
@@ -32,13 +32,7 @@ func TestConcat(t *testing.T) {
 			require.EqualValues(t, i, <-concatenated)
 		}
 
-		select {
-		case _, ok := <-concatenated:
-			if ok {
-				assert.FailNow(t, "channel contains unexpected items")
-			}
-		default:
-		}
+		assert.Empty(t, concatenated)
 	}()
 
 	testutils.FailOnTimeout(ctx, t, 1*time.Second)
@@ -135,13 +129,7 @@ func TestFromValues(t *testing.T) {
 			require.EqualValues(t, i, <-values)
 		}
 
-		select {
-		case _, ok := <-values:
-			if ok {
-				assert.FailNow(t, "channel contains unexpected items")
-			}
-		default:
-		}
+		assert.Empty(t, values)
 	}()
 
 	testutils.FailOnTimeout(ctx, t, 1*time.Second)
@@ -172,13 +160,7 @@ func TestRange(t *testing.T) {
 			require.EqualValues(t, i, <-values)
 		}
 
-		select {
-		case _, ok := <-values:
-			if ok {
-				assert.FailNow(t, "channel contains unexpected items")
-			}
-		default:
-		}
+		assert.Empty(t, values)
 	}()
 
 	testutils.FailOnTimeout(ctx, t, 1*time.Second)
@@ -197,13 +179,7 @@ func TestRangeBig(t *testing.T) {
 			require.EqualValues(t, big.NewInt(int64(i)), <-values)
 		}
 
-		select {
-		case _, ok := <-values:
-			if ok {
-				assert.FailNow(t, "channel contains unexpected items")
-			}
-		default:
-		}
+		assert.Empty(t, values)
 	}()
 
 	testutils.FailOnTimeout(ctx, t, 1*time.Second)
@@ -222,13 +198,7 @@ func TestRangeBigExcl(t *testing.T) {
 			require.EqualValues(t, big.NewInt(int64(i)), <-values)
 		}
 
-		select {
-		case _, ok := <-values:
-			if ok {
-				assert.FailNow(t, "channel contains unexpected items")
-			}
-		default:
-		}
+		assert.Empty(t, values)
 	}()
 
 	testutils.FailOnTimeout(ctx, t, 1*time.Second)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/go-errors/errors v1.4.2
-	github.com/matryer/moq v0.3.0
+	github.com/matryer/moq v0.3.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/exp v0.0.0-20221018221608-02f3b879a704

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/matryer/moq v0.3.0 h1:4j0goF/XK3pMTc7fJB3fveuTJoQNdavRX/78vlK3Xb4=
-github.com/matryer/moq v0.3.0/go.mod h1:RJ75ZZZD71hejp39j4crZLsEDszGk6iH4v4YsWFKH4s=
+github.com/matryer/moq v0.3.1 h1:kLDiBJoGcusWS2BixGyTkF224aSCD8nLY24tj/NcTCs=
+github.com/matryer/moq v0.3.1/go.mod h1:RJ75ZZZD71hejp39j4crZLsEDszGk6iH4v4YsWFKH4s=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/test/assertions.go
+++ b/test/assertions.go
@@ -1,0 +1,19 @@
+package testutils
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+// FailOnTimeout blocks until `ctx` is done or until specified timeout has elapsed.
+// In the latter case it calls require.FailNow(t, "test timed out").
+func FailOnTimeout(ctx context.Context, t *testing.T, timeout time.Duration) {
+	select {
+	case <-ctx.Done():
+		// context got cancelled in time, nothing to do
+	case <-time.After(timeout):
+		require.FailNow(t, "test timed out")
+	}
+}

--- a/test/assertions.go
+++ b/test/assertions.go
@@ -1,18 +1,17 @@
 package testutils
 
 import (
-	"context"
 	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 )
 
-// FailOnTimeout blocks until `ctx` is done or until specified timeout has elapsed.
+// FailOnTimeout blocks until `done` is closed or until specified timeout has elapsed.
 // In the latter case it calls require.FailNow(t, "test timed out").
-func FailOnTimeout(ctx context.Context, t *testing.T, timeout time.Duration) {
+func FailOnTimeout(t *testing.T, done <-chan struct{}, timeout time.Duration) {
 	select {
-	case <-ctx.Done():
-		// context got cancelled in time, nothing to do
+	case <-done:
+		// test is done, nothing to do
 	case <-time.After(timeout):
 		require.FailNow(t, "test timed out")
 	}


### PR DESCRIPTION
## Description

New functions:
- `Concat[T any](channels ...<-chan T) <-chan T`
- `Empty[T any]() <-chan T`
- `Range[T constraints.Integer](from, to T) <-chan T`
- `RangeBig(from, to *big.Int) <-chan *big.Int`
- `FromValues[T any](values ...T) <-chan T`
- Allow to optionally set capacity of the output channel in `Map`: `Map[T, S any](source <-chan T, f func(T) S) <-chan S` -> `Map[T, S any](source <-chan T, f func(T) S, capacity ...int) <-chan S`
- By default use unbuffered output channels in `Flatten` and `Map` .

## Todos

- [x] Unit tests
- [x] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [x] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
